### PR TITLE
Fix README documentation accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ No build dependencies required. Optional components for enhanced detection:
 
 ### Download binary (recommended)
 
-Download the latest release for your platform from [Releases](https://github.com/severity1/open-guard/releases).
+Download the latest release for your platform from [Releases](https://github.com/severity1/open-guard-engine/releases).
 
 ```bash
 # Linux/macOS - make executable
@@ -123,13 +123,6 @@ agent:
   provider: claude          # "claude" (default) or "ollama"
   model: claude-sonnet-4-20250514
   # endpoint: http://localhost:11434  # Only for ollama provider
-
-allowlist:
-  domains:
-    - github.com
-    - api.anthropic.com
-  paths:
-    - /home/user/safe-directory
 ```
 
 ### Decision Modes

--- a/cmd/open-guard/main.go
+++ b/cmd/open-guard/main.go
@@ -103,15 +103,6 @@ func newCheckCmd() *cobra.Command {
 					cmd.Printf("    Endpoint: %s\n", cfg.Agent.Endpoint)
 				}
 			}
-			cmd.Printf("  Allowlisted Domains: %d\n", len(cfg.Allowlist.Domains))
-
-			if verbose {
-				cmd.Printf("\nAllowlisted Domains:\n")
-				for _, d := range cfg.Allowlist.Domains {
-					cmd.Printf("  - %s\n", d)
-				}
-			}
-
 			return nil
 		},
 	}

--- a/cmd/open-guard/main_test.go
+++ b/cmd/open-guard/main_test.go
@@ -297,15 +297,11 @@ func TestMapCategory(t *testing.T) {
 func TestCheckCommand_VerboseMode(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create config with allowlisted domains
+	// Create config
 	configContent := `
 mode: confirm
 llm:
   enabled: false
-allowlist:
-  domains:
-    - example.com
-    - test.org
 `
 	err := os.WriteFile(filepath.Join(tmpDir, ".open-guard.yaml"), []byte(configContent), 0644)
 	require.NoError(t, err)
@@ -321,10 +317,6 @@ allowlist:
 	output := buf.String()
 	assert.Contains(t, output, "Configuration valid")
 	assert.Contains(t, output, "confirm")
-	// Verbose mode shows allowlisted domains
-	assert.Contains(t, output, "Allowlisted Domains")
-	assert.Contains(t, output, "example.com")
-	assert.Contains(t, output, "test.org")
 }
 
 func TestAnalyzeCommand_StrictMode_Blocks(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix release URL from `open-guard` to `open-guard-engine`
- Remove unimplemented allowlist feature from documentation and code

## Changes

- **README.md**: Fixed release URL, removed allowlist config example
- **internal/config/config.go**: Removed `Allowlist` struct, methods, and merge logic
- **internal/config/config_test.go**: Removed allowlist-related tests
- **cmd/open-guard/main.go**: Removed allowlist display from `check` command
- **cmd/open-guard/main_test.go**: Updated verbose mode test

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass (590s)
- [x] `check` command works correctly
- [x] `analyze` command works correctly