### PR TITLE
fix: eliminate race condition in Ollama env setup, increase coverage to 95.5%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,8 @@ stdin -> Layer 0: Encoding Detection (decode obfuscated content)
 ## Git Insights
 
 **Recent Design Decisions:**
+- Extracted collectResponse() for testability and improved context cancellation handling (PR #4)
+- Race condition fix: replaced setupOllamaEnv (parent env mutation) with buildEnv (subprocess env map) to eliminate shared state mutation (PR #8)
 - Strict validation for ThreatCategory and Config values to fail fast on invalid YAML/config (PR #15)
 - Exported Analyzer interface for external testing and mocking (PR #12)
 - Tool-agnostic pattern matching (not tied to specific tool names)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ stdin -> Layer 0: Encoding Detection (decode obfuscated content)
 **Recent Design Decisions:**
 - Extracted collectResponse() for testability and improved context cancellation handling (PR #4)
 - Race condition fix: replaced setupOllamaEnv (parent env mutation) with buildEnv (subprocess env map) to eliminate shared state mutation (PR #8)
+- buildEnv() returns new map each call to ensure concurrent access safety and isolation
 - Strict validation for ThreatCategory and Config values to fail fast on invalid YAML/config (PR #15)
 - Exported Analyzer interface for external testing and mocking (PR #12)
 - Tool-agnostic pattern matching (not tied to specific tool names)

--- a/internal/agent/CLAUDE.md
+++ b/internal/agent/CLAUDE.md
@@ -67,6 +67,7 @@ The analyzer runs in a hardened sandbox:
 - Table-driven tests with `testify/assert` and `testify/require`
 - Custom `mockIterator` for testing `collectResponse()` with various scenarios
 - Tests for context cancellation, `ErrNoMoreMessages` handling, and error propagation
+- `buildEnv()` tests verify map isolation and concurrent access safety
 - TDD approach: tests written before implementation (e.g., `buildEnv()` tests)
 - Coverage: 95.5% as of commit cad6545
 

--- a/internal/agent/analyzer_test.go
+++ b/internal/agent/analyzer_test.go
@@ -509,23 +509,6 @@ func TestCollectResponse_EmptyResponse(t *testing.T) {
 	assert.Contains(t, err.Error(), "empty response")
 }
 
-func TestCollectResponse_NonAssistantMessage(t *testing.T) {
-	// Non-AssistantMessage types should be skipped without error
-	iter := &mockIterator{
-		messages: []claudecode.Message{
-			&claudecode.AssistantMessage{
-				Content: []claudecode.ContentBlock{
-					&claudecode.TextBlock{Text: "SAFE"},
-				},
-			},
-		},
-	}
-
-	result, err := collectResponse(context.Background(), iter)
-	require.NoError(t, err)
-	assert.True(t, result.Safe)
-}
-
 func TestClaudeAnalyzer_BuildEnv(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Replace `setupOllamaEnv()` (process-global `os.Setenv` race condition) with `buildEnv()` that returns a `map[string]string` for the subprocess via SDK's `WithEnv()` option
- Extract `collectResponse()` from `Analyze()` for testability - accepts `claudecode.MessageIterator` interface, enabling mock-based testing of the iterator loop
- Fix all errcheck violations in the agent package (8 issues resolved)
- Increase agent package test coverage from 60.9% to 95.5% with 15+ new tests

## Test Plan
- [x] `go test -race ./internal/agent/...` - all tests pass, no races detected
- [x] `go test -race ./...` - full project passes with race detector
- [x] `go test -cover ./internal/agent/` - 95.5% coverage (target was 80%)
- [x] `golangci-lint run ./...` - zero issues in agent package (15 pre-existing in other packages)
- [x] `make build` - binary builds
- [x] `go vet ./...` - clean
- [x] Concurrent `buildEnv()` test with 10 goroutines and `-race` flag
- [x] Map isolation test verifying independent allocations per call
- [x] Mock iterator tests covering: safe/injection text, multiple messages, iterator errors, context cancellation, empty response

## Review Summary
- **Security review**: APPROVED WITH COMMENTS - race condition fully eliminated, security sandbox intact, env leak prevention improved (ANTHROPIC_API_KEY cleared for subprocess)
- **Code quality review**: APPROVED WITH COMMENTS - clean Go idioms, proper error handling, thorough test coverage

Closes #8
Closes #4