### PR TITLE
feat: add anti-slop directives to tdd-team workflow

### DIFF
--- a/.claude/commands/tdd-team.md
+++ b/.claude/commands/tdd-team.md
@@ -160,7 +160,7 @@ Exit conditions (ALL must be true):
 
 ## QA Criteria
 - RED phase: existing quality gates pass, new tests FAIL as expected, no regressions
-- GREEN phase: all quality gates pass (per task success criteria)
+- GREEN phase: all quality gates pass (per task success criteria). Flag tests that contribute no unique coverage or don't test what their name claims.
 - Review fix regression: all quality gates pass (per task success criteria)
 
 ## Review Handoff
@@ -217,7 +217,7 @@ When the verifier messages that QA GREEN is complete:
 4. Reviewers complete their review, challenge each other's findings, and work with the implementer to resolve issues
 5. When all reviewers converge on APPROVED, mark "Review" task complete to unblock PR
 
-The lead designs review prompts based on the changes. Use `paranoid-sentinel` for security review if available, `general-purpose` otherwise.
+The lead designs review prompts based on the changes. Use `paranoid-sentinel` for security review if available, `general-purpose` otherwise. When the diff contains AI-generated code, include a directive in reviewer prompts to identify and flag AI slop patterns.
 
 ### Review Loop
 


### PR DESCRIPTION
## Summary
- Verifier QA GREEN criteria now includes directive to flag tests with no unique coverage or misleading names
- Review dispatch instructs lead to include AI slop detection in reviewer prompts when diff contains AI-generated code

## Context
PR #30 shipped a test where the name/comment claimed to test non-assistant message skipping but the body only contained an AssistantMessage - a duplicate contributing zero coverage. This passed AI reviewers. These two additions address the gap without adding new agents or prescribed checklists.

## Test plan
- [x] Changes are documentation-only (slash command prompt), no code affected
- [x] Verified markdown formatting and YAML frontmatter intact